### PR TITLE
feat: separate between `vector` and `raster` types

### DIFF
--- a/app/components/map/Map.js
+++ b/app/components/map/Map.js
@@ -41,7 +41,7 @@ function Map() {
             {rasterList.map((r, i) => {
                 if (r.type == 'vector') {
                     return <Source key={r.id} id={`source-${r.id}`} type={r.type} url={`pmtiles://${r.url}`}>
-                        <Layer id={`layer-${r.id}`} type={'fill'} source={`source-${r.id}`} source-layer={`source-${r.id}`} layout={{ visibility: r.visibility }} paint={{ "fill-opacity": r.opacity / 100 }} />
+                        <Layer id={`layer-${r.id}`} type={'fill'} source={`source-${r.id}`} source-layer={r.name.toLowerCase()} layout={{ visibility: r.visibility }} paint={{ "fill-opacity": r.opacity / 100 }} />
                     </Source>
                 }
                 return <Source key={r.id} id={`source-${r.id}`} type={r.type} url={`pmtiles://${r.url}`}>

--- a/app/components/map/Map.js
+++ b/app/components/map/Map.js
@@ -39,6 +39,9 @@ function Map() {
 
         >
             {rasterList.map((r, i) => {
+                if (r.type == 'vector') {
+                    return
+                }
                 return <Source key={r.id} id={`source-${r.id}`} type={r.type} url={`pmtiles://${r.url}`}>
                     <Layer id={`layer-${r.id}`} type={r.type} source={`source-${r.id}`} layout={{ visibility: r.visibility }} paint={{ "raster-opacity": r.opacity / 100 }} />
                 </Source>

--- a/app/components/map/Map.js
+++ b/app/components/map/Map.js
@@ -41,7 +41,7 @@ function Map() {
             {rasterList.map((r, i) => {
                 if (r.type == 'vector') {
                     return <Source key={r.id} id={`source-${r.id}`} type={r.type} url={`pmtiles://${r.url}`}>
-                        <Layer id={`layer-${r.id}`} type={'fill'} source={`source-${r.id}`} source-layer={`source-${r.id}`} layout={{ visibility: r.visibility }} paint={{ "raster-opacity": r.opacity / 100 }} />
+                        <Layer id={`layer-${r.id}`} type={'fill'} source={`source-${r.id}`} source-layer={`source-${r.id}`} layout={{ visibility: r.visibility }} paint={{ "fill-opacity": r.opacity / 100 }} />
                     </Source>
                 }
                 return <Source key={r.id} id={`source-${r.id}`} type={r.type} url={`pmtiles://${r.url}`}>

--- a/app/components/map/Map.js
+++ b/app/components/map/Map.js
@@ -40,7 +40,9 @@ function Map() {
         >
             {rasterList.map((r, i) => {
                 if (r.type == 'vector') {
-                    return
+                    return <Source key={r.id} id={`source-${r.id}`} type={r.type} url={`pmtiles://${r.url}`}>
+                        <Layer id={`layer-${r.id}`} type={r.type} source={`source-${r.id}`} source-layer={`source-${r.id}`} layout={{ visibility: r.visibility }} paint={{ "raster-opacity": r.opacity / 100 }} />
+                    </Source>
                 }
                 return <Source key={r.id} id={`source-${r.id}`} type={r.type} url={`pmtiles://${r.url}`}>
                     <Layer id={`layer-${r.id}`} type={r.type} source={`source-${r.id}`} layout={{ visibility: r.visibility }} paint={{ "raster-opacity": r.opacity / 100 }} />

--- a/app/components/map/Map.js
+++ b/app/components/map/Map.js
@@ -41,7 +41,7 @@ function Map() {
             {rasterList.map((r, i) => {
                 if (r.type == 'vector') {
                     return <Source key={r.id} id={`source-${r.id}`} type={r.type} url={`pmtiles://${r.url}`}>
-                        <Layer id={`layer-${r.id}`} type={r.type} source={`source-${r.id}`} source-layer={`source-${r.id}`} layout={{ visibility: r.visibility }} paint={{ "raster-opacity": r.opacity / 100 }} />
+                        <Layer id={`layer-${r.id}`} type={'fill'} source={`source-${r.id}`} source-layer={`source-${r.id}`} layout={{ visibility: r.visibility }} paint={{ "raster-opacity": r.opacity / 100 }} />
                     </Source>
                 }
                 return <Source key={r.id} id={`source-${r.id}`} type={r.type} url={`pmtiles://${r.url}`}>


### PR DESCRIPTION
I ran the code and confirmed that we are getting errors specifically related to the Mapbox Layer Specification:

<img width="1637" alt="vector layer errors" src="https://github.com/user-attachments/assets/b4a2169a-a9df-455d-a261-7d00851fc2c7">

`layer-3` also made sense because i see that `Base.js` has the [vector source as its third entry](https://github.com/wri/cities-data-explorer/blob/CCE-59/app/Base.js#L13):
```javascript
  const [rasterList, setRasterList] = useState([
    { id: "1", name: "Landcover", url: "https://wri-cities-heat.s3.amazonaws.com/ZAF-Cape_town/processed/citycentre_landcover_rgb.pmtiles", type: "raster", visibility: "visible", opacity: 100 },
    { id: "2", name: "UTCI", url: "https://wri-cities-heat.s3.amazonaws.com/ZAF-Cape_town/processed/utci/UTCI_2022_22_1200.pmtiles", type: "raster", visibility: "visible", opacity: 100 },
    { id: "3", name: "Buildings", url: "https://wri-cities-heat.s3.amazonaws.com/ZAF-Cape_town/processed/ZAF-Cape_Town-overture_buildings.pmtiles", type: "vector", visibility: "visible", opacity: 100 }
  ]);
```

So, I separated out the raster `<Source/>`s from the vector in the [first commit](https://github.com/wri/cities-data-explorer/commit/c99bc40559ab8231b85cd554b99f4981031b947f).

This removed the errors from the console and got me back to $\color{green}{\textsf{GREEN}}$ (the app was running without errors).

----
# The first error `source-layer`
`react-map-gl` [docs](https://visgl.github.io/react-map-gl/docs/api-reference/layer) has a link to the [Mapbox layer specification](https://docs.mapbox.com/style-spec/reference/layers). That's where I went next.

The `source-layer` property from the first error made sense looking at the [spec](https://docs.mapbox.com/style-spec/reference/layers/#source-layer) (it's **required**):

<img width="1534" alt="source-layer-required" src="https://github.com/user-attachments/assets/3e6b61c6-950b-48c8-a186-bdc3ce95d3c9">

So, I added `source-layer` to the vector source block [on my second commit](https://github.com/wri/cities-data-explorer/pull/3/commits/66986de0327d23894686cb6a413243a4a11fd730) and noticed the the error vanished. 🤞 

----

# The second error `type`
The `type` property from the second error made sense looking at the [spec](https://docs.mapbox.com/style-spec/reference/layers/#type). We'd been using `raster` value. Now, since we have a vector layer of `buildings` I decided to use the `fill` value:

<img width="1744" alt="fill-property" src="https://github.com/user-attachments/assets/65fcb56a-533c-4c30-a8e1-8b2a48c3cf3b">

I got rid of the error in the [next commit](https://github.com/wri/cities-data-explorer/commit/ac706db78fae04520b26f509917209aba1162773), but a new one popped up:

<img width="1167" alt="raster-opacity-error" src="https://github.com/user-attachments/assets/33c9392d-ee8f-45bb-ad32-376d7214f54c">

----

# The third error `opacity`
The `raster-opacity` property was unknown. That makes sense since it's a vector layer. So, I searched for `opacity` in the spec. I found it under the `fill` type which is what I used to fix the previous error. I expected that it was an old property and should work with MapLibre. But, I checked the version to make sure:

<img width="1775" alt="fill-opacity" src="https://github.com/user-attachments/assets/17b3ba07-46a1-4ba8-b83e-09d8f11f6097">

Sweet! No rendering errors! But, what?!?!?! I still don't see the buildings! 🤔 

<img width="1202" alt="Screenshot 2024-08-22 at 8 27 02 PM" src="https://github.com/user-attachments/assets/076542aa-0789-4f54-ae24-d08a5c427a34">

----

# Success!

Ah! The layer name in the vector datasource has to be an exact match. The current name of the source is `Buildings`, and I know that the layer is named in lowercase: `buildings`. So, I [made that change](https://github.com/wri/cities-data-explorer/commit/c8b68b15d3f2a7e01a0a9f9b9d0e8582b6e435b8) and 💥 it worked!

<img width="1277" alt="Screenshot 2024-08-22 at 8 37 16 PM" src="https://github.com/user-attachments/assets/71eed98f-0769-4d15-bb2e-4a2d9ef28502">

----

# Change the fill color

Check out the rest of the style spec for other style properties. For example, [fill-color](https://docs.mapbox.com/style-spec/reference/layers/#paint-fill-fill-color) will probably be the next step for styling:

<img width="1779" alt="Screenshot 2024-08-22 at 8 41 39 PM" src="https://github.com/user-attachments/assets/518adfda-391a-4d78-bf31-16b7a326c6d2">




